### PR TITLE
custom node by updating the Dockerfile to install the `ComfyUI_LoadImageFromHttpURL` extension

### DIFF
--- a/Serverless.Dockerfile
+++ b/Serverless.Dockerfile
@@ -32,6 +32,16 @@ RUN git clone https://github.com/comfyanonymous/ComfyUI.git && \
     pip install --no-cache-dir librosa soundfile av moviepy
 
 # ------------------------------------------------------------
+# Install ComfyUI Custom Nodes
+# ------------------------------------------------------------
+# Install comfyui-mixlab-nodes (provides LoadImageFromHttpURL node)
+RUN mkdir -p /workspace/ComfyUI/custom_nodes && \
+    cd /workspace/ComfyUI/custom_nodes && \
+    git clone https://github.com/shadowcz007/comfyui-mixlab-nodes.git && \
+    cd comfyui-mixlab-nodes && \
+    (pip install --no-cache-dir -r requirements.txt 2>/dev/null || echo "No requirements.txt or installation optional")
+
+# ------------------------------------------------------------
 # Volume Model Setup - Models come from S3 Network Volume
 # ------------------------------------------------------------
 # Create empty Model Directories for ComfyUI

--- a/Serverless.Dockerfile
+++ b/Serverless.Dockerfile
@@ -34,11 +34,11 @@ RUN git clone https://github.com/comfyanonymous/ComfyUI.git && \
 # ------------------------------------------------------------
 # Install ComfyUI Custom Nodes
 # ------------------------------------------------------------
-# Install comfyui-mixlab-nodes (provides LoadImageFromHttpURL node)
+# Install LoadImageFromHttpURL custom node
 RUN mkdir -p /workspace/ComfyUI/custom_nodes && \
     cd /workspace/ComfyUI/custom_nodes && \
-    git clone https://github.com/shadowcz007/comfyui-mixlab-nodes.git && \
-    cd comfyui-mixlab-nodes && \
+    git clone https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL.git && \
+    cd ComfyUI_LoadImageFromHttpURL && \
     (pip install --no-cache-dir -r requirements.txt 2>/dev/null || echo "No requirements.txt or installation optional")
 
 # ------------------------------------------------------------

--- a/Serverless.Dockerfile
+++ b/Serverless.Dockerfile
@@ -39,7 +39,12 @@ RUN mkdir -p /workspace/ComfyUI/custom_nodes && \
     cd /workspace/ComfyUI/custom_nodes && \
     git clone https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL.git && \
     cd ComfyUI_LoadImageFromHttpURL && \
-    (pip install --no-cache-dir -r requirements.txt 2>/dev/null || echo "No requirements.txt or installation optional")
+    if [ -f requirements.txt ]; then \
+        echo "Installing dependencies from requirements.txt..." && \
+        pip install --no-cache-dir -r requirements.txt; \
+    else \
+        echo "No requirements.txt found, skipping dependency installation"; \
+    fi
 
 # ------------------------------------------------------------
 # Volume Model Setup - Models come from S3 Network Volume


### PR DESCRIPTION
This pull request adds support for a ComfyUI custom node by updating the Dockerfile to install the `ComfyUI_LoadImageFromHttpURL` extension. This allows the application to load images from HTTP URLs within ComfyUI.

Custom node installation:

* Updated `Serverless.Dockerfile` to clone the `ComfyUI_LoadImageFromHttpURL` repository into the `custom_nodes` directory and install its dependencies, enabling the use of the LoadImageFromHttpURL custom node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Installs the `ComfyUI_LoadImageFromHttpURL` custom node and its dependencies in `Serverless.Dockerfile`.
> 
> - **Build/Docker**:
>   - Install ComfyUI custom node `ComfyUI_LoadImageFromHttpURL` by cloning into `ComfyUI/custom_nodes` and conditionally installing its `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a7ed11cd8bb2f64a03e9f50972ba617e919cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->