### PR TITLE
Disable URL truncation in logging for S3 uploads in rp_handler.py

### DIFF
--- a/rp_handler.py
+++ b/rp_handler.py
@@ -30,7 +30,7 @@ COMFYUI_BASE_URL = f"http://{COMFYUI_HOST}:{COMFYUI_PORT}"
 DEFAULT_WORKFLOW_DURATION_SECONDS = 60  # Default fallback for workflow start time
 SUPPORTED_IMAGE_EXTENSIONS = ["*.png", "*.jpg", "*.jpeg", "*.webp", "*.gif"]
 SUPPORTED_VIDEO_EXTENSIONS = ["*.mp4", "*.webm", "*.mov", "*.avi"]
-URL_TRUNCATE_LENGTH = 100  # Maximum characters to display when logging URLs
+# URL_TRUNCATE_LENGTH = 100  # Maximum characters to display when logging URLs - DISABLED
 
 # Global variable to track the ComfyUI process
 _comfyui_process = None
@@ -177,7 +177,7 @@ def _upload_to_s3(file_path: Path, job_id: str) -> dict:
             )
         
         print(f"✅ S3 Upload successful: {s3_key}")
-        print(f"🔗 URL: {url[:URL_TRUNCATE_LENGTH]}...")
+        print(f"🔗 URL: {url}")
         
         return {
             "success": True,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces truncated S3 URL logging with a sanitizer that redacts presigned query params and logs full safe URLs.
> 
> - **Logging (S3 uploads)**:
>   - Add `rp_handler.py::_sanitize_url_for_logging` to strip sensitive query params (e.g., `X-Amz-Signature`) from presigned URLs.
>   - Update `_upload_to_s3` to log sanitized URL via `safe_url` instead of truncating.
>   - Remove `URL_TRUNCATE_LENGTH` constant and associated truncation logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b657c8c1d9f1573cb63b52fcdeb5ddd37ba3f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->