### PR TITLE
Fix S3 URL debugging for presigned URLs

### DIFF
--- a/rp_handler.py
+++ b/rp_handler.py
@@ -218,7 +218,11 @@ def _upload_to_s3(file_path: Path, job_id: str) -> dict:
         # Sanitize URL for logging to avoid exposing presigned URL tokens
         safe_url = _sanitize_url_for_logging(url)
         print(f"🔗 URL: {safe_url}")
-        print(f"🔗 Full URL (for debugging): {url}")
+        
+        # Only log full URL with auth tokens if explicitly enabled (security risk)
+        if _parse_bool_env("DEBUG_S3_URLS", "false"):
+            print(f"🔍 DEBUG: Full URL with auth tokens: {url}")
+            print("⚠️  WARNING: Full S3 URLs contain sensitive authentication tokens!")
         
         return {
             "success": True,


### PR DESCRIPTION
## Problem
S3 URLs werden nicht angezeigt, weil die presigned URL Query-Parameter für Sicherheit entfernt werden. Das macht Debugging schwierig.

## Lösung
- Füge Debug-Log hinzu, das die vollständige presigned URL zeigt
- Behält die sichere URL-Sanitization für normale Logs bei
- Hilft beim Troubleshooting von URL-Zugriffsproblemen

## Änderungen
- `rp_handler.py`: Debug-Log für vollständige S3 URL hinzugefügt
- Sicherheit bleibt gewährleistet durch separate sanitized URL

## Testing
- S3 Upload funktioniert weiterhin
- Debug-Logs zeigen vollständige URLs
- Normale Logs bleiben sicher

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a debug log to print the full presigned S3 URL while retaining sanitized URL in normal logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33ad86693afde4d95d69015fb0df186f611f8153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->